### PR TITLE
Update 'current_branch' output to strip tag prefix

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -55,7 +55,7 @@ runs:
           fi
         else
           REF=${{ github.ref }}
-          REF_BRANCH=${REF/refs\/tags\//}
+          REF_BRANCH=${REF/refs\/tags\/${{ inputs.strip_tag_prefix }}/}
           echo "::set-output name=current_branch::$REF_BRANCH"
         fi
       shell: bash


### PR DESCRIPTION
Title might be self explanatory, basically 'strip_tag_prefix' is only being considered for the 'tag' output and ignored for 'current_branch'.

I think this change should be applied for the sake of consistency (and because I'd actually use it lol).

Change shouldn't break anything as it's just replicating what is done in the tag step.
Current tag step:
```sh
TAG=${REF/refs\/tags\/${{ inputs.strip_tag_prefix }}/}
```
Suggested change to current_branch step:
```sh
REF_BRANCH=${REF/refs\/tags\/${{ inputs.strip_tag_prefix }}/}
```

Thanks! o/