### PR TITLE
feat: add support for writing to GITHUB_OUTPUT file

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -46,19 +46,27 @@ runs:
 
           BASE_REF=${BASE_REF/refs\/heads\//}
           HEAD_REF=${HEAD_REF/refs\/heads\//}
-
-          echo "::set-output name=base_ref_branch::$(eval printf "%s" "$BASE_REF")"
-          echo "::set-output name=head_ref_branch::$(eval printf "%s" "$HEAD_REF")"
-
           REF_BRANCH=${REF/refs\/pull\//}
           REF_BRANCH=${REF_BRANCH/refs\/heads\//}
-
-          echo "::set-output name=ref_branch::$(eval printf "%s" "$REF_BRANCH")"
+          
+          if [[ -z "$GITHUB_OUTPUT" ]]; then
+            echo "::set-output name=base_ref_branch::$(eval printf "%s" "$BASE_REF")"
+            echo "::set-output name=head_ref_branch::$(eval printf "%s" "$HEAD_REF")"
+            echo "::set-output name=ref_branch::$(eval printf "%s" "$REF_BRANCH")"
+          else
+            echo "base_ref_branch=$(eval printf "%s" "$BASE_REF")" >> "$GITHUB_OUTPUT"
+            echo "head_ref_branch=$(eval printf "%s" "$HEAD_REF")" >> "$GITHUB_OUTPUT"
+            echo "ref_branch=$(eval printf "%s" "$REF_BRANCH")" >> "$GITHUB_OUTPUT"
+          fi
         else
           BASE_REF=$(printf "%q" "${{ github.event.base_ref }}")
           BASE_REF=${BASE_REF/refs\/heads\/${{ inputs.strip_tag_prefix }}/}
-
-          echo "::set-output name=base_ref_branch::$(eval printf "%s" "$BASE_REF")"
+          
+          if [[ -z "$GITHUB_OUTPUT" ]]; then
+            echo "::set-output name=base_ref_branch::$(eval printf "%s" "$BASE_REF")"
+          else
+            echo "base_ref_branch=$(eval printf "%s" "$BASE_REF")" >> "$GITHUB_OUTPUT"
+          fi
         fi
       shell: bash
     - id: current_branch
@@ -66,9 +74,17 @@ runs:
         # "Set the current branch name..."
         if [[ "${{ github.ref }}" != "refs/tags/"* ]]; then
           if [[ ${{ github.event_name }} == 'pull_request' ]]; then
-            echo "::set-output name=current_branch::${{ steps.branch.outputs.head_ref_branch }}"
+            if [[ -z "$GITHUB_OUTPUT" ]]; then
+              echo "::set-output name=current_branch::${{ steps.branch.outputs.head_ref_branch }}"
+            else
+              echo "current_branch=${{ steps.branch.outputs.head_ref_branch }}" >> "$GITHUB_OUTPUT"
+            fi
           else
-            echo "::set-output name=current_branch::${{ steps.branch.outputs.ref_branch }}"
+            if [[ -z "$GITHUB_OUTPUT" ]]; then
+              echo "::set-output name=current_branch::${{ steps.branch.outputs.ref_branch }}"
+            else
+              echo "current_branch=${{ steps.branch.outputs.ref_branch }}" >> "$GITHUB_OUTPUT"
+            fi
           fi
         fi
       shell: bash
@@ -77,11 +93,21 @@ runs:
         # "Set the default branch name..."
         if [[ "${{ github.ref }}" != "refs/tags/"* ]]; then
           if [[ "${{ steps.current_branch.outputs.current_branch }}" == "${{ github.event.repository.default_branch }}" ]]; then
-            echo "::set-output name=is_default::true"
-            echo "::set-output name=default_branch::${{ github.event.repository.default_branch }}"
+            if [[ -z "$GITHUB_OUTPUT" ]]; then
+              echo "::set-output name=is_default::true"
+              echo "::set-output name=default_branch::${{ github.event.repository.default_branch }}"
+            else
+              echo "is_default=true" >> "$GITHUB_OUTPUT"
+              echo "default_branch=${{ github.event.repository.default_branch }}" >> "$GITHUB_OUTPUT"
+            fi
           else
-            echo "::set-output name=is_default::false"
-            echo "::set-output name=default_branch::${{ github.event.repository.default_branch }}"
+            if [[ -z "$GITHUB_OUTPUT" ]]; then
+              echo "::set-output name=is_default::false"
+              echo "::set-output name=default_branch::${{ github.event.repository.default_branch }}"
+            else
+              echo "is_default=false" >> "$GITHUB_OUTPUT"
+              echo "default_branch=${{ github.event.repository.default_branch }}" >> "$GITHUB_OUTPUT"
+            fi
           fi
         fi
       shell: bash
@@ -92,10 +118,19 @@ runs:
           REF=$(printf "%q" "${{ github.ref }}")
           TAG=${REF/refs\/tags\/${{ inputs.strip_tag_prefix }}/}
 
-          echo "::set-output name=tag::$(eval printf "%s" "$TAG")"
-          echo "::set-output name=is_tag::true"
+          if [[ -z "$GITHUB_OUTPUT" ]]; then
+            echo "::set-output name=tag::$(eval printf "%s" "$TAG")"
+            echo "::set-output name=is_tag::true"
+          else
+            echo "tag=$(eval printf "%s" "$TAG")" >> "$GITHUB_OUTPUT"
+            echo "is_tag=true" >> "$GITHUB_OUTPUT"
+          fi
         else
-          echo "::set-output name=is_tag::false"
+          if [[ -z "$GITHUB_OUTPUT" ]]; then
+            echo "::set-output name=is_tag::false"
+          else
+            echo "is_tag=false" >> "$GITHUB_OUTPUT"
+          fi
         fi
       shell: bash
 


### PR DESCRIPTION
[::set-output is being deprecated soon and >>$GITHUB_OUTPUT will work as of runner version 2.297.0](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)

Closes: #180 